### PR TITLE
Fix Misspellings

### DIFF
--- a/photochem/cython/EvoAtmosphere.pyx
+++ b/photochem/cython/EvoAtmosphere.pyx
@@ -321,7 +321,7 @@ cdef class EvoAtmosphere:
     Parameters
     ----------
     temperature : ndarray[double,ndim=1]
-        new temperature at each atomspheric layer
+        new temperature at each atmospheric layer
     trop_alt : float, optional
         Tropopause altitude (cm). Only necessary if rainout == True, 
         or fix_water_in_trop == True.
@@ -657,7 +657,7 @@ cdef class EvoAtmosphere:
     return out
 
   property T_surf:
-    """double. The surface temperature (K). Only relevent when doing time-dependent
+    """double. The surface temperature (K). Only relevant when doing time-dependent
     photochemical-climate simulation.
     """
     def __get__(self):
@@ -730,7 +730,7 @@ cdef class EvoAtmosphere:
 
   property top_atmos_adjust_frac:
     """Sets the fractional amount that the top of the model domain changes
-    when integration is haulted by `P_top_min` or `P_top_max`
+    when integration is halted by `P_top_min` or `P_top_max`
     """
     def __get__(self):
       cdef double val

--- a/photochem/cython/PhotochemVars.pyx
+++ b/photochem/cython/PhotochemVars.pyx
@@ -100,7 +100,7 @@ cdef class PhotochemVars:
       return val
   
   property z:
-    "ndarray[double,dim=1], shape (nz). The altitude of the center of each atmopsheric layer (cm)"
+    "ndarray[double,dim=1], shape (nz). The altitude of the center of each atmospheric layer (cm)"
     def __get__(self):
       cdef int dim1
       var_pxd.photochemvars_z_get_size(self._ptr, &dim1)
@@ -313,7 +313,7 @@ cdef class PhotochemVars:
       var_pxd.photochemvars_mxsteps_set(self._ptr, &val)
       
   property equilibrium_time:
-    "double. Atomsphere considered in equilibrium if integrations reaches this time (seconds)"
+    "double. Atmosphere considered in equilibrium if integrations reaches this time (seconds)"
     def __get__(self):
       cdef double val
       var_pxd.photochemvars_equilibrium_time_get(self._ptr, &val)
@@ -375,7 +375,7 @@ cdef class PhotochemVars:
 
   property autodiff:
     """bool. If True, then the chemistry terms of the Jacobian are computed uses 
-    foward mode automatic differentiation.
+    forward mode automatic differentiation.
     """
     def __get__(self):
       cdef bool val

--- a/photochem/cython/PhotochemWrk.pyx
+++ b/photochem/cython/PhotochemWrk.pyx
@@ -31,7 +31,7 @@ cdef class PhotochemWrk:
       return val
 
   property nsteps:
-    "int. Number of integration steps excuted. Updated after every successful step."
+    "int. Number of integration steps executed. Updated after every successful step."
     def __get__(self):
       cdef int val
       wrk_pxd.photochemwrk_nsteps_get(self._ptr, &val)

--- a/photochem/extensions/gasgiants.py
+++ b/photochem/extensions/gasgiants.py
@@ -418,7 +418,7 @@ class EvoAtmosphereGasGiant(EvoAtmosphere):
         ----------
         include_deep_atmosphere : bool, optional
             If True, then results will include portions of the deep
-            atomsphere that are not part of the photochemical grid, by default True
+            atmosphere that are not part of the photochemical grid, by default True
 
         Returns
         -------

--- a/photochem/extensions/hotrocks.py
+++ b/photochem/extensions/hotrocks.py
@@ -299,7 +299,7 @@ class AdiabatClimateThermalEmission(AdiabatClimate):
         return converged
 
     def set_custom_albedo(self, wv, albedo):
-        """Sets a cutsom surface albedo/emissivity. The input is 
+        """Sets a custom surface albedo/emissivity. The input is 
         constantly extrapolated.
 
         Parameters

--- a/photochem/utils/_convert_atmos.py
+++ b/photochem/utils/_convert_atmos.py
@@ -2,7 +2,7 @@ from ._format import FormatReactions_main, FormatSettings_main, MyDumper, yaml
 from ._convert_utils import generate_photo_yaml_entries, sort_photos
     
 def atmos2yaml(rx_file, species_file, outfile, photo_database = "Photochem", with_citations = False):
-    """Converts Atmos reactions to .yaml format compatable with Photochem
+    """Converts Atmos reactions to .yaml format compatible with Photochem
 
     Parameters
     ----------

--- a/photochem/utils/_convert_cantera.py
+++ b/photochem/utils/_convert_cantera.py
@@ -59,7 +59,7 @@ def photochem2cantera_main(data):
     # delete reverse-reactions
     if "reverse-reactions" in data:
         if data['reverse-reactions'] == False:
-            raise Exception("Can only convert to Cantera if reactions are reversable")
+            raise Exception("Can only convert to Cantera if reactions are reversible")
         del data['reverse-reactions']  
 
     # Cantera can't handle > 2 temperature ranges for thermodynamic data

--- a/photochem/utils/_format.py
+++ b/photochem/utils/_format.py
@@ -33,7 +33,7 @@ def FormatReactions(filename, outfile):
     filename : str
         Path of input reaction network file.
     outfile : str
-        Path of output formated reaction network file.
+        Path of output formatted reaction network file.
 
     """
     fil = open(filename,'r')
@@ -308,7 +308,7 @@ def resave_mechanism_with_atoms(
     remove_particles : bool, optional
         If True, then all particles are removed, by default False
     remove_reaction_particles : bool, optional
-        If True, then partcles forming from reactions are removed, by default False
+        If True, then particles forming from reactions are removed, by default False
     """    
 
     with open(infile,'r') as f:

--- a/photochem/utils/stars.py
+++ b/photochem/utils/stars.py
@@ -539,7 +539,7 @@ def hazmat_spectrum(star_name, model='model', outputfile=None, Teq=None, stellar
     return wv, F
 
 def print_hazmat_stars():
-    "Prints the stars avaliable in the HAZMAT catalogue"
+    "Prints the stars available in the HAZMAT catalogue"
     print(HAZMAT_STARS_YAML)
 
 HAZMAT_STARS_YAML = \
@@ -724,7 +724,7 @@ def closest_muscles_to_Teff(Teff):
     return out
 
 def print_muscles_stars():
-    "Prints the stars avaliable in the MUSCLES catalogue"
+    "Prints the stars available in the MUSCLES catalogue"
     print(MUSCLES_STARS_YAML)
 
 # All the MUSCLES stars for which we could easily get stellar properties.

--- a/photochem/utils/youngsun.py
+++ b/photochem/utils/youngsun.py
@@ -136,7 +136,7 @@ def youngsun(timega, grid):
     relphotokuruczgrid = np.zeros(len(wave))
     relphotokuruczgrid[99:] = photothen[99:]/photonow[99:]
     # wave[100]=69.5 nm, and photonow is 0 below this. In the final code,
-    # we only consider the photospheric contribution above 150nm anway...
+    # we only consider the photospheric contribution above 150nm anyway...
 
     # 8) interpolate kurucz grid to Thuillier wavelength grid
     wave = wave*10.0 # convert kurucz wavelength grid to Angstroms

--- a/src/evoatmosphere/photochem_evoatmosphere.f90
+++ b/src/evoatmosphere/photochem_evoatmosphere.f90
@@ -24,7 +24,7 @@ module photochem_evoatmosphere
 
     logical :: evolve_climate
     ! Below are only relevant for evolve_climate = .true.
-    !> The surface temperature (K). Only relevent when doing time-dependent
+    !> The surface temperature (K). Only relevant when doing time-dependent
     !> photochemical-climate simulation.
     real(dp) :: T_surf
     !> Assumed tropopause temperature for climate calculations (K).
@@ -47,7 +47,7 @@ module photochem_evoatmosphere
     !> top of the atmosphere has a smaller pressure than `P_top_max`.
     real(dp) :: P_top_max = 1.0e50_dp
     !> Sets the fractional amount that the top of the model domain changes
-    !> when integration is haulted by `P_top_min` or `P_top_max`
+    !> when integration is halted by `P_top_min` or `P_top_max`
     real(dp) :: top_atmos_adjust_frac = 0.02
 
   contains
@@ -333,7 +333,7 @@ module photochem_evoatmosphere
     !> Changes the temperature profile.
     module subroutine set_temperature(self, temperature, trop_alt, err)
       class(EvoAtmosphere), target, intent(inout) :: self
-      real(dp), intent(in) :: temperature(:) !! new temperature at each atomspheric layer
+      real(dp), intent(in) :: temperature(:) !! new temperature at each atmospheric layer
       real(dp), optional, intent(in) :: trop_alt !! Tropopause altitude (cm). Only necessary if
                                                  !! rainout == True, or fix_water_in_trop == True.
       character(:), allocatable, intent(out) :: err

--- a/src/evoatmosphere/photochem_evoatmosphere_rhs.f90
+++ b/src/evoatmosphere/photochem_evoatmosphere_rhs.f90
@@ -823,7 +823,7 @@ contains
                         + wrk%DD(i,1)*wrk%usol(i,1) + wrk%ADD(i,1)*wrk%usol(i,1) &
                         + var%lower_flux(i)/var%dz(1)
       ! Moses (2001) boundary condition for gas giants
-      ! A deposition velocity controled by how quickly gases
+      ! A deposition velocity controlled by how quickly gases
       ! turbulantly mix vertically
       elseif (var%lowerboundcond(i) == MosesBC) then
         rhs(i) = rhs(i) + wrk%DU(i,1)*wrk%usol(i,2) + wrk%ADU(i,1)*wrk%usol(i,2) &
@@ -856,7 +856,7 @@ contains
         rhs(i) = rhs(i) + var%lower_flux(i)/var%dz(1)
         else
         ! If the height is within the model domain, then we will distribute the flux
-        ! throught the model.
+        ! throughout the model.
         jdisth = minloc(var%Z,1, var%Z >= disth) - 1
         jdisth = max(jdisth,2)
         ztop = var%z(jdisth)-var%z(1)

--- a/src/evoatmosphere/photochem_evoatmosphere_rhs_climate.f90
+++ b/src/evoatmosphere/photochem_evoatmosphere_rhs_climate.f90
@@ -187,7 +187,7 @@ contains
 
     ! check inputs
     if (T_surf < T_trop) then
-      err = "Surface temperature is lower then the tropopause temperture"
+      err = "Surface temperature is lower then the tropopause temperature"
       return
     endif
 

--- a/src/input/photochem_input_read.f90
+++ b/src/input/photochem_input_read.f90
@@ -265,7 +265,7 @@ contains
     ! now we now nq, the number of PDEs
     dat%nq = dat%npq + dat%nll
     
-    ! we also now nsp, the index of the backgorund gas 
+    ! we also now nsp, the index of the background gas 
     dat%nsp = dat%npq + dat%ng
     
     ! species_mass, species_composition, and species_names
@@ -744,7 +744,7 @@ contains
     allocate(var%only_eddy(dat%nq))
     allocate(var%rate_fcns(dat%nq))
     ! default boundary conditions
-    var%lowerboundcond(:dat%np) = VelocityBC ! default particle BC is alway velocity
+    var%lowerboundcond(:dat%np) = VelocityBC ! default particle BC is always velocity
     var%lowerboundcond(dat%ng_1:) = s%default_lowerboundcond ! can be -1 (Moses) or 0 (velocity)
     var%lower_vdep = 0.0_dp
     var%upperboundcond = VelocityBC
@@ -2637,7 +2637,7 @@ contains
     ! reads in alt
     ind = findloc(labels,'alt')
     if (ind(1) /= 0) then
-      dat%z_file(:) = temp(ind(1),:)*1.e5_dp ! conver to cm
+      dat%z_file(:) = temp(ind(1),:)*1.e5_dp ! convert to cm
     else
       err = '"alt" was not found in input file '//trim(atmosphere_txt)
       return

--- a/src/photochem_common.f90
+++ b/src/photochem_common.f90
@@ -50,7 +50,7 @@ contains
         n = rp%eff%n_eff
         do j = 1,var%nz
           eff_den(j) = density(j)*rp%eff%def_eff
-          ! subtract the default efficiency, then add the perscribed one
+          ! subtract the default efficiency, then add the prescribed one
           do k = 1,n ! if n is 0 then it will be skipped
             l = rp%eff%eff_sp_inds(k)
             eff_den(j) = eff_den(j) - rp%eff%def_eff*densities(l,j) &
@@ -66,7 +66,7 @@ contains
         n = rp%eff%n_eff
         do j = 1,var%nz
           eff_den(j) = density(j)*rp%eff%def_eff
-          ! subtract the default efficiency, then add the perscribed one
+          ! subtract the default efficiency, then add the prescribed one
           do k = 1,n ! if n is 0 then it will be skipped
             l = rp%eff%eff_sp_inds(k)
             eff_den(j) = eff_den(j) - rp%eff%def_eff*densities(l,j) &
@@ -390,7 +390,7 @@ contains
       wH2O(var%trop_ind) = 1.d-20
     endif
     ! Here we re-scale the rainfall rate so that is the the same as what
-    ! is perscribed in the settings file. This means that distribution of
+    ! is prescribed in the settings file. This means that distribution of
     ! raining is controlled by H2O vs z, but magnitude is fixed.
     total_rainfall = var%rainfall_rate*earth_rainfall_rate
     scale_factor = total_rainfall/sum(wH2O*var%dz(1))

--- a/src/photochem_radtran.f90
+++ b/src/photochem_radtran.f90
@@ -87,7 +87,7 @@ contains
     Ssfc = Rsfc*direct(nz+1)
       
     ! Coefficients of tridiagonal linear system (Equations 39 - 43)
-    ! Odd coeficients (Equation 41)
+    ! Odd coefficients (Equation 41)
     A(1) = 0.0_dp
     B(1) = e1(1)
     D(1) = -e2(1)

--- a/src/photochem_types.f90
+++ b/src/photochem_types.f90
@@ -437,7 +437,7 @@ module photochem_types ! make a giant IO object
     ! Custom optical properties
     real(dp), allocatable :: tauc(:,:) !! (nz,nw) Custom optical depth in each layer
     real(dp), allocatable :: w0c(:,:) !! (nz,nw) Custom single scattering albedo
-    real(dp), allocatable :: g0c(:,:) !! (nz,nw) Custom asymetry parameter
+    real(dp), allocatable :: g0c(:,:) !! (nz,nw) Custom asymmetry parameter
     
     ! output
     logical :: at_photo_equilibrium = .false.
@@ -453,7 +453,7 @@ module photochem_types ! make a giant IO object
     !> works better when atol is smaller (e.g., atol = ~1.0e-18).
     real(c_double) :: atol = 1.0e-23_dp 
     integer :: mxsteps = 100000 !! max number of steps before integrator will give up.
-    !> seconds. atomsphere considered in equilibrium if integrations reaches this time.
+    !> seconds. atmosphere considered in equilibrium if integrations reaches this time.
     real(dp) :: equilibrium_time = 1.0e17_dp
     !> For convergence checking. Considers mixing ratio change between t_now and time 
     !> t = t_now*conv_hist_factor to see if atmosphere is changing.
@@ -466,13 +466,13 @@ module photochem_types ! make a giant IO object
     !> Threshold normalized change in mixing ratios per time change for
     !> convergence checking.
     real(dp) :: conv_longdydt = 1.0e-6_dp
-    real(c_double) :: initial_dt = 1.0e-6_dp !! intial timestep size (seconds)
+    real(c_double) :: initial_dt = 1.0e-6_dp !! initial timestep size (seconds)
     !> Maximum time step size (seconds).
     real(c_double) :: max_dt = sqrt(huge(1.0_dp))
     integer(c_int) :: max_err_test_failures = 15 !! CVODE max error test failures
     integer(c_int) :: max_order = 5 !! CVODE max order for BDF method.
     !> If .true., then the chemistry terms of the Jacobian are computed uses 
-    !> foward mode automatic differentiation.
+    !> forward mode automatic differentiation.
     logical :: autodiff = .true.
     !> Perturbation for finite difference Jacobian calculation, when autodiff == .false.
     real(dp) :: epsj = 1.0e-4_dp 
@@ -538,7 +538,7 @@ module photochem_types ! make a giant IO object
     type(SundialsData) :: sun !! CVODE data
 
     ! All for determining convergence
-    integer :: nsteps = 0 !! Number of integration steps excuted. Updated
+    integer :: nsteps = 0 !! Number of integration steps executed. Updated
                           !! after every successful step.
     !> History of times at previous integration steps. Index 1 is current, 
     !> while index 2, 3, 4 are previous steps. Updated after every successful step.


### PR DESCRIPTION
This PR fixes non-breaking misspellings across the codebase. See <https://github.com/Nicholaswogan/photochem/issues/42> for more details.

There remain some misspellings which are breaking changes which have not been corrected: 

<details>

<img width="892" height="123" alt="Screenshot 2026-05-13 at 14 19 45" src="https://github.com/user-attachments/assets/9e783c97-4d6a-4db5-8412-e81efec33e47" />


</details>